### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = " chmod +x faitagram && chmod +x setup.py"

--- a/README.md
+++ b/README.md
@@ -60,3 +60,4 @@ Specific tutorial will be on NullByte, I would put a link after I make a tutoria
 How it works:
 
    This script uses selenium web driver, and Xvfb and pyvirtualdisplay to make the web driver invisible so you can keep doing work, this script also uses STEM as the proxy.
+[![Run on Repl.it](https://repl.it/badge/github/Juniorn1003/Faitagram)](https://repl.it/github/Juniorn1003/Faitagram)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@bryanhodges05tr/Faitagram-2).